### PR TITLE
Fix _wrapped_func swallows return val

### DIFF
--- a/src/aws_secretsmanager_caching/decorators.py
+++ b/src/aws_secretsmanager_caching/decorators.py
@@ -46,7 +46,7 @@ class InjectSecretString:
             """
             Internal function to execute wrapped function
             """
-            func(secret, *args, **kwargs)
+            return func(secret, *args, **kwargs)
 
         return _wrapped_func
 
@@ -99,6 +99,6 @@ class InjectKeywordedSecretString:
             """
             Internal function to execute wrapped function
             """
-            func(*args, **resolved_kwargs, **kwargs)
+            return func(*args, **resolved_kwargs, **kwargs)
 
         return _wrapped_func

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -56,8 +56,9 @@ class TestAwsSecretsManagerCachingInjectKeywordedSecretStringDecorator(unittest.
             self.assertEqual(secret['username'], func_username)
             self.assertEqual(secret['password'], func_password)
             self.assertEqual(keyworded_argument, 'foo')
+            return 'OK'
 
-        function_to_be_decorated()
+        self.assertEqual(function_to_be_decorated(), 'OK')
 
     def test_valid_json_with_mixed_args(self):
         secret = {
@@ -170,8 +171,9 @@ class TestAwsSecretsManagerCachingInjectSecretStringDecorator(unittest.TestCase)
             self.assertEqual(arg1, secret)
             self.assertEqual(arg2, 'foo')
             self.assertEqual(arg3, 'bar')
+            return 'OK'
 
-        function_to_be_decorated('foo', 'bar')
+        self.assertEqual(function_to_be_decorated('foo', 'bar'), 'OK')
 
     def test_string_with_additional_kwargs(self):
         secret = 'not json'


### PR DESCRIPTION
*Description of changes:*

The return value of wrapped functions is swallowed by the decorator. This fix conveys the wrapped function's return value to its caller.

Without this change, any decorated function is unable to return a value to its caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
