### PR TITLE
`SecretCacheConfig`: ensure that the default `secret_refresh_interval` is the correct type (`int`)

### DIFF
--- a/src/aws_secretsmanager_caching/config.py
+++ b/src/aws_secretsmanager_caching/config.py
@@ -54,7 +54,7 @@ class SecretCacheConfig:
         "exception_retry_growth_factor": 2,
         "exception_retry_delay_max": 3600,
         "default_version_stage": "AWSCURRENT",
-        "secret_refresh_interval": timedelta(hours=1).total_seconds(),
+        "secret_refresh_interval": int(timedelta(hours=1).total_seconds()),
         "secret_cache_hook": None
     }
 


### PR DESCRIPTION
*Description of changes:*

I'm running Python 3.10 and was getting a 
> _DeprecationWarning: [non-integer arguments to randrange()](https://docs.python.org/3/whatsnew/3.10.html#deprecated) have been deprecated since Python 3.10_

warning buried deep in my code. Turns out one of my dependencies has `aws-secretsmanager-caching-python` as a dependency and so this warning is being triggered as a result of this line in this package: https://github.com/aws/aws-secretsmanager-caching-python/blob/3ffb18de7bb218e6a55ddddaf7746c1de8955d95/src/aws_secretsmanager_caching/cache/items.py#L203

Where the `ttl` is `3600.0`. Looking into it, it seems like this is the default value https://github.com/aws/aws-secretsmanager-caching-python/blob/428bd926ace4a8466b93938f9300dae84dd82c33/src/aws_secretsmanager_caching/config.py#L57

However the docs say this should be an `int` not a `float` https://github.com/aws/aws-secretsmanager-caching-python/blob/3ffb18de7bb218e6a55ddddaf7746c1de8955d95/src/aws_secretsmanager_caching/config.py#L41-L43

So I figured that's the best place to resolve this warning (ignoring the fact that this package only officially supports up until Python 3.7)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
