### PR TITLE
Remove use of `datetime.utcnow` which was marked as deprecated in Python 3.12

### DIFF
--- a/test/integ/test_aws_secretsmanager_caching.py
+++ b/test/integ/test_aws_secretsmanager_caching.py
@@ -13,7 +13,7 @@
 import inspect
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import botocore
@@ -39,7 +39,7 @@ class TestAwsSecretsManagerCachingInteg:
     def pre_test_cleanup(self, client):
         logger.info('Starting cleanup operation of previous test secrets...')
         old_secrets = []
-        two_days_ago = datetime.now() - timedelta(days=2)
+        two_days_ago = datetime.now(timezone.utc) - timedelta(days=2)
 
         paginator = client.get_paginator('list_secrets')
         paginator_config = {'PageSize': 10, 'StartingToken': None}


### PR DESCRIPTION
*Description of changes:*

Starting in Python 3.12, the `datetime.utcnow` method has been [deprecated](https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated) and [according to the docs](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow):

> the recommended way to create an object representing the current time in UTC is by calling `datetime.now(timezone.utc)`

I'm not sure that this library is still being maintained but thought I'd share for those who can fork and still want to use it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
