### PR TITLE
Python 3.10 and 3.12 compatibility changes and package version compatibility updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/aws_secretsmanager_caching/config.py
+++ b/src/aws_secretsmanager_caching/config.py
@@ -13,7 +13,6 @@
 """Secret cache configuration object."""
 
 from copy import deepcopy
-from datetime import timedelta
 
 
 class SecretCacheConfig:
@@ -54,7 +53,7 @@ class SecretCacheConfig:
         "exception_retry_growth_factor": 2,
         "exception_retry_delay_max": 3600,
         "default_version_stage": "AWSCURRENT",
-        "secret_refresh_interval": timedelta(hours=1).total_seconds(),
+        "secret_refresh_interval": 3600,
         "secret_cache_hook": None
     }
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -14,8 +14,10 @@
 Unit test suite for items module
 """
 import unittest
+from types import NoneType
 
 from aws_secretsmanager_caching.config import SecretCacheConfig
+from aws_secretsmanager_caching.cache.secret_cache_hook import SecretCacheHook
 
 
 class TestSecretCacheConfig(unittest.TestCase):
@@ -33,3 +35,7 @@ class TestSecretCacheConfig(unittest.TestCase):
         stage = 'nothing'
         config = SecretCacheConfig(default_version_stage=stage)
         self.assertEqual(config.default_version_stage, stage)
+
+    def test_default_secret_refresh_interval_typing(self):
+        config = SecretCacheConfig()
+        self.assertIsInstance(config.secret_refresh_interval, int)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -14,10 +14,8 @@
 Unit test suite for items module
 """
 import unittest
-from types import NoneType
 
 from aws_secretsmanager_caching.config import SecretCacheConfig
-from aws_secretsmanager_caching.cache.secret_cache_hook import SecretCacheHook
 
 
 class TestSecretCacheConfig(unittest.TestCase):

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -50,43 +50,43 @@ class TestSecretCacheObject(unittest.TestCase):
         sco._exception = Exception("test")
         self.assertRaises(Exception, sco.get_secret_value)
     def test_datetime_fix_is_refresh_needed(self):
-        sco = TestSecretCacheObject.TestObject(SecretCacheConfig(), None, None)
+        secret_cached_object = TestSecretCacheObject.TestObject(SecretCacheConfig(), None, None)
 
-        # Used to pass branching requirements (False is not None)
-        sco._next_retry_time = datetime.now(tz=timezone.utc)
-        sco._refresh_needed = False
-        sco._exception = not None
+        # Variable values set in order to be able to test modified line with assert statement (False is not None)
+        secret_cached_object._next_retry_time = datetime.now(tz=timezone.utc)
+        secret_cached_object._refresh_needed = False
+        secret_cached_object._exception = not None
 
-        self.assertTrue(sco._is_refresh_needed())
+        self.assertTrue(secret_cached_object._is_refresh_needed())
 
     def test_datetime_fix__refresh(self):
         exp_factor = 11
 
-        sco = SecretCacheObject(
+        secret_cached_object = SecretCacheObject(
             SecretCacheConfig(exception_retry_delay_base=1, exception_retry_growth_factor=2),
             None, None
         )
-        sco._set_result = Mock(side_effect=Exception("exception used for test"))
-        sco._refresh_needed = True
-        sco._exception_count = exp_factor  # delay = min(1*(2^exp_factor) = 2048, 3600)
+        secret_cached_object._set_result = Mock(side_effect=Exception("exception used for test"))
+        secret_cached_object._refresh_needed = True
+        secret_cached_object._exception_count = exp_factor  # delay = min(1*(2^exp_factor) = 2048, 3600)
 
         t_before = datetime.now(tz=timezone.utc)
-        sco._SecretCacheObject__refresh()
+        secret_cached_object._SecretCacheObject__refresh()
         t_after = datetime.now(tz=timezone.utc)
 
         t_before_delay = t_before + timedelta(
-            milliseconds=sco._config.exception_retry_delay_base * (
-                    sco._config.exception_retry_growth_factor ** exp_factor
+            milliseconds=secret_cached_object._config.exception_retry_delay_base * (
+                    secret_cached_object._config.exception_retry_growth_factor ** exp_factor
             )
         )
-        self.assertLessEqual(t_before_delay, sco._next_retry_time)
+        self.assertLessEqual(t_before_delay, secret_cached_object._next_retry_time)
 
         t_after_delay = t_after + timedelta(
-            milliseconds=sco._config.exception_retry_delay_base * (
-                    sco._config.exception_retry_growth_factor ** exp_factor
+            milliseconds=secret_cached_object._config.exception_retry_delay_base * (
+                    secret_cached_object._config.exception_retry_growth_factor ** exp_factor
             )
         )
-        self.assertGreaterEqual(t_after_delay, sco._next_retry_time)
+        self.assertGreaterEqual(t_after_delay, secret_cached_object._next_retry_time)
 class TestSecretCacheItem(unittest.TestCase):
     def setUp(self):
         pass
@@ -97,21 +97,21 @@ class TestSecretCacheItem(unittest.TestCase):
     def test_datetime_fix_SCI_init(self):
         config = SecretCacheConfig()
         t_before = datetime.now(tz=timezone.utc)
-        sci = SecretCacheItem(config, None, None)
+        secret_cache_item = SecretCacheItem(config, None, None)
         t_after = datetime.now(tz=timezone.utc)
 
-        self.assertGreaterEqual(sci._next_refresh_time, t_before)
-        self.assertLessEqual(sci._next_refresh_time, t_after)
+        self.assertGreaterEqual(secret_cache_item._next_refresh_time, t_before)
+        self.assertLessEqual(secret_cache_item._next_refresh_time, t_after)
     def test_datetime_fix_refresh_needed(self):
         config = SecretCacheConfig()
-        sci = SecretCacheItem(config, None, None)
+        secret_cache_item = SecretCacheItem(config, None, None)
 
-        # Used to pass branching requirements (False is not None)
-        sci._refresh_needed = False
-        sci._exception = False
-        sci._next_retry_time = None
+        # Variable values set in order to be able to test modified line with assert statement (False is not None)
+        secret_cache_item._refresh_needed = False
+        secret_cache_item._exception = False
+        secret_cache_item._next_retry_time = None
 
-        self.assertTrue(sci._is_refresh_needed())
+        self.assertTrue(secret_cache_item._is_refresh_needed())
 
     def test_datetime_fix_execute_refresh(self):
         client_mock = Mock()
@@ -119,16 +119,16 @@ class TestSecretCacheItem(unittest.TestCase):
         client_mock.describe_secret.return_value = "test"
 
         config = SecretCacheConfig()
-        sci = SecretCacheItem(config, client_mock, None)
+        secret_cache_item = SecretCacheItem(config, client_mock, None)
 
         t_before = datetime.now(tz=timezone.utc)
-        sci._execute_refresh()
+        secret_cache_item._execute_refresh()
         t_after = datetime.now(tz=timezone.utc)
 
         # Make sure that the timezone is correctly set
-        self.assertEqual(sci._next_refresh_time.tzinfo, timezone.utc)
+        self.assertEqual(secret_cache_item._next_refresh_time.tzinfo, timezone.utc)
 
         # Check that secret_refresh_interval addition works as intended
-        self.assertGreaterEqual(sci._next_refresh_time, t_before)
+        self.assertGreaterEqual(secret_cache_item._next_refresh_time, t_before)
         t_max_after = t_after + timedelta(seconds=config.secret_refresh_interval)
-        self.assertLessEqual(sci._next_refresh_time, t_max_after)
+        self.assertLessEqual(secret_cache_item._next_refresh_time, t_max_after)

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -14,8 +14,10 @@
 Unit test suite for items module
 """
 import unittest
+from datetime import timezone, datetime, timedelta
+from unittest.mock import Mock
 
-from aws_secretsmanager_caching.cache.items import SecretCacheObject
+from aws_secretsmanager_caching.cache.items import SecretCacheObject, SecretCacheItem
 from aws_secretsmanager_caching.config import SecretCacheConfig
 
 
@@ -47,3 +49,86 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertIsNone(sco.get_secret_value())
         sco._exception = Exception("test")
         self.assertRaises(Exception, sco.get_secret_value)
+    def test_datetime_fix_is_refresh_needed(self):
+        sco = TestSecretCacheObject.TestObject(SecretCacheConfig(), None, None)
+
+        # Used to pass branching requirements (False is not None)
+        sco._next_retry_time = datetime.now(tz=timezone.utc)
+        sco._refresh_needed = False
+        sco._exception = not None
+
+        self.assertTrue(sco._is_refresh_needed())
+
+    def test_datetime_fix__refresh(self):
+        exp_factor = 11
+
+        sco = SecretCacheObject(
+            SecretCacheConfig(exception_retry_delay_base=1, exception_retry_growth_factor=2),
+            None, None
+        )
+        sco._set_result = Mock(side_effect=Exception("exception used for test"))
+        sco._refresh_needed = True
+        sco._exception_count = exp_factor  # delay = min(1*(2^exp_factor) = 2048, 3600)
+
+        t_before = datetime.now(tz=timezone.utc)
+        sco._SecretCacheObject__refresh()
+        t_after = datetime.now(tz=timezone.utc)
+
+        t_before_delay = t_before + timedelta(
+            milliseconds=sco._config.exception_retry_delay_base * (
+                    sco._config.exception_retry_growth_factor ** exp_factor
+            )
+        )
+        self.assertLessEqual(t_before_delay, sco._next_retry_time)
+
+        t_after_delay = t_after + timedelta(
+            milliseconds=sco._config.exception_retry_delay_base * (
+                    sco._config.exception_retry_growth_factor ** exp_factor
+            )
+        )
+        self.assertGreaterEqual(t_after_delay, sco._next_retry_time)
+class TestSecretCacheItem(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_datetime_fix_SCI_init(self):
+        config = SecretCacheConfig()
+        t_before = datetime.now(tz=timezone.utc)
+        sci = SecretCacheItem(config, None, None)
+        t_after = datetime.now(tz=timezone.utc)
+
+        self.assertGreaterEqual(sci._next_refresh_time, t_before)
+        self.assertLessEqual(sci._next_refresh_time, t_after)
+    def test_datetime_fix_refresh_needed(self):
+        config = SecretCacheConfig()
+        sci = SecretCacheItem(config, None, None)
+
+        # Used to pass branching requirements (False is not None)
+        sci._refresh_needed = False
+        sci._exception = False
+        sci._next_retry_time = None
+
+        self.assertTrue(sci._is_refresh_needed())
+
+    def test_datetime_fix_execute_refresh(self):
+        client_mock = Mock()
+        client_mock.describe_secret = Mock()
+        client_mock.describe_secret.return_value = "test"
+
+        config = SecretCacheConfig()
+        sci = SecretCacheItem(config, client_mock, None)
+
+        t_before = datetime.now(tz=timezone.utc)
+        sci._execute_refresh()
+        t_after = datetime.now(tz=timezone.utc)
+
+        # Make sure that the timezone is correctly set
+        self.assertEqual(sci._next_refresh_time.tzinfo, timezone.utc)
+
+        # Check that secret_refresh_interval addition works as intended
+        self.assertGreaterEqual(sci._next_refresh_time, t_before)
+        t_max_after = t_after + timedelta(seconds=config.secret_refresh_interval)
+        self.assertLessEqual(sci._next_refresh_time, t_max_after)


### PR DESCRIPTION
removed unnecessarily added imports (cleanup)

added tests to confirm proper behavior of `datetime.utcnow()` to `datetime.now(tz=timezone.utc)` python 3.12 fix

added simple test to confirm default typing

changed datetime.utcnow() to datetime.now(tz=timezone.utc) due to deprecation in python 3.12

changed config call to datetime for hour to second conversion (returned a float) to integer

*Issue #, if available:*
Closes #30 
Closes #37 
Closes #38 

*Description of changes:*
These changes are fixes for `datetime.utcnow()` [deprecation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) in python 3.10 and the [change](https://docs.python.org/3.10/library/random.html#random.randrange) in `randint` to only accept integer arguments.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
