### PR TITLE
Python 3.10 and 3.12 compatibility changes and package version compatibility updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/aws_secretsmanager_caching/config.py
+++ b/src/aws_secretsmanager_caching/config.py
@@ -13,7 +13,6 @@
 """Secret cache configuration object."""
 
 from copy import deepcopy
-from datetime import timedelta
 
 
 class SecretCacheConfig:
@@ -54,7 +53,7 @@ class SecretCacheConfig:
         "exception_retry_growth_factor": 2,
         "exception_retry_delay_max": 3600,
         "default_version_stage": "AWSCURRENT",
-        "secret_refresh_interval": timedelta(hours=1).total_seconds(),
+        "secret_refresh_interval": 3600,
         "secret_cache_hook": None
     }
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -33,3 +33,7 @@ class TestSecretCacheConfig(unittest.TestCase):
         stage = 'nothing'
         config = SecretCacheConfig(default_version_stage=stage)
         self.assertEqual(config.default_version_stage, stage)
+
+    def test_default_secret_refresh_interval_typing(self):
+        config = SecretCacheConfig()
+        self.assertIsInstance(config.secret_refresh_interval, int)


### PR DESCRIPTION
added tests to confirm proper behavior of datetime.utcnow() to datetime.now(tz=timezone.utc) python 3.12 fix

added simple test to confirm default typing

changed datetime.utcnow() to datetime.now(tz=timezone.utc) due to deprecation in python 3.12

changed config call to datetime for hour to second conversion (returned a float) to integer

Issue #, if available:
Closes https://github.com/aws/aws-secretsmanager-caching-python/pull/30
Closes https://github.com/aws/aws-secretsmanager-caching-python/pull/37
Closes https://github.com/aws/aws-secretsmanager-caching-python/issues/38

Description of changes:
These changes are fixes for datetime.utcnow() [deprecation](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) in python 3.10 and the [change](https://docs.python.org/3.10/library/random.html#random.randrange) in randint to only accept integer arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.