### PR TITLE
fix TypeError on python 3.12

### DIFF
--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -200,7 +200,7 @@ class SecretCacheItem(SecretCacheObject):
         """
         result = self._client.describe_secret(SecretId=self._secret_id)
         ttl = self._config.secret_refresh_interval
-        self._next_refresh_time = datetime.now(timezone.utc) + timedelta(seconds=randint(round(ttl / 2), ttl))
+        self._next_refresh_time = datetime.now(timezone.utc) + timedelta(seconds=randint(round(ttl / 2), round(ttl)))
         return result
 
     def _get_version(self, version_stage):


### PR DESCRIPTION
When attempting to use the AWS Secrets Manager Python caching client on a Docker image based on `python:3.12`, I encounter the following exception:
```  File "/usr/local/lib/python3.12/site-packages/aws_secretsmanager_caching/cache/items.py", line 203, in _execute_refresh
    self._next_refresh_time = datetime.utcnow() + timedelta(seconds=randint(round(ttl / 2), ttl))
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/random.py", line 336, in randint
    return self.randrange(a, b+1)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/random.py", line 312, in randrange
    istop = _index(stop)
            ^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```

This is because `ttl` is a float, and `random.randrange` wants an int.

My fix converts `ttl` to an int using `round`; I've confirmed that the exception is no longer thrown.

Thanks for considering my fix, and for all your hard work on this library!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
