### PR TITLE
Adding cache level refreshNow functionality

### DIFF
--- a/src/aws_secretsmanager_caching/secret_cache.py
+++ b/src/aws_secretsmanager_caching/secret_cache.py
@@ -99,3 +99,11 @@ class SecretCache:
         if secret is None:
             return secret
         return secret.get("SecretBinary")
+
+    def refresh_secret_now(self, secret_id):
+        """Immediately refresh the secret in the cache.
+
+        :type secret_id: str
+        :param secret_id: The secret identifier
+        """
+        self._get_cached_secret(secret_id).refresh_secret_now()


### PR DESCRIPTION
*Issue #, if available:*
#16 

*Description of changes:*
Adding refreshNow at the cache level instead of using private methods at the secret level

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
