### PR TITLE
Update README.md to reflect importlib.metadata usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The AWS Secrets Manager Python caching client enables in-process caching of secr
 
 To use this client you must have:
 
-* Python 3.7 or newer.  Use of Python versions 3.6 or older are not supported.
+* Python 3.8 or newer.  Use of Python versions 3.7 or older are not supported.
 * An Amazon Web Services (AWS) account to access secrets stored in AWS Secrets Manager.
   * **To create an AWS account**, go to [Sign In or Create an AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) and then choose **I am a new user.** Follow the instructions to create an AWS account.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     keywords='secretsmanager secrets manager development cache caching client',
     use_scm_version=True,
-    python_requires='>3.5',
+    python_requires='>=3.8',
     install_requires=['botocore'],
     setup_requires=['pytest-runner', 'setuptools-scm'],
     tests_require=['pytest', 'pytest-cov', 'pytest-sugar', 'codecov']


### PR DESCRIPTION
`importlib.metadata` was introduced in python 3.8 but our guidance says 3.7 and up will work

*Issue #, if available:* https://github.com/aws/aws-secretsmanager-caching-python/issues/53

*Description of changes:* Changed python versions in README


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
