### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-secretsmanager-caching-python/security/code-scanning/12](https://github.com/aws/aws-secretsmanager-caching-python/security/code-scanning/12)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. The best practice is to set `contents: read` at the workflow level, which covers most use cases for CI workflows that only need to check out code and run tests. If any step requires additional permissions (such as uploading coverage reports to a pull request), those can be added as needed. In this case, since the workflow uploads coverage to Codecov (which does not require write access to the repository), `contents: read` is sufficient. The change should be made at the top level of the workflow file, just after the `name` key and before the `on` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
