### PR TITLE
Add integ test workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -1,0 +1,40 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test:
+    if: |
+      github.event_name != 'pull_request_target' ||
+      contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+          role-session-name: python-caching-${{ github.run_id }}
+          aws-region: us-west-2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -e .
+      - name: Run integ tests
+        run: |
+          pytest --no-cov test/integ/

--- a/.github/workflows/pr_sync.yml
+++ b/.github/workflows/pr_sync.yml
@@ -1,0 +1,31 @@
+name: Remove safe-to-test label when new commits are pushed
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+
+    steps:
+      - name: Remove label
+        run: |
+          echo "Removing label '$LABEL_NAME' from PR #$PR_NUMBER on repo $REPO" 
+          gh_status=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels/$LABEL_NAME" -X DELETE | jq 'if type == "object" then .status else empty end' --raw-output)
+          case $gh_status in
+            "") echo "Label removed" ;;
+            404) echo "Label not found — ignoring" ;;
+            *) echo "unexpected HTTP $gh_status" && exit 1 ;;
+          esac
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL_NAME: safe-to-test
+          REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Automate running integration tests.


### What is changing?

1. Add workflow to run integration tests.
2. Add workflow to remove the safe-to-test label when new commits are added.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Tested on my fork.

### When testing locally, provide testing artifact(s):

1. https://github.com/simonmarty/aws-secretsmanager-caching-python/actions/runs/23772036941/job/69265512669

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
