### PR TITLE
correct retry backoff units and make refresh_secret_now cache under lock

### DIFF
--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -136,7 +136,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
 
         if self._exception is not None:
             now = datetime.now(timezone.utc)
-            exception_sleep = max((self._next_retry_time - now).total_seconds() * 1000, 0)
+            exception_sleep = (self._next_retry_time - now).total_seconds() * 1000
             sleep = max(exception_sleep, sleep)
 
         # Divide by 1000 for millis

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -20,8 +20,6 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from random import randint
 
-from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError, NoRegionError
-
 from .lru import LRUCache
 
 
@@ -52,50 +50,6 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         self._exception_count = 0
         self._refresh_needed = True
         self._next_retry_time = None
-
-    # Throttling is the only transient error that carries a 4xx status, so it
-    # must be matched by error code rather than by the status check below.
-    _THROTTLING_ERROR_CODES = frozenset({
-        "ThrottlingException",
-        "TooManyRequestsException",
-        "Throttling",
-    })
-
-    @staticmethod
-    def _is_transient_error(e):
-        """Determine whether a refresh exception is transient (worth retrying).
-
-        Only configuration errors and clear 4xx client errors (e.g.
-        ResourceNotFound, AccessDenied) are permanent. Everything else --
-        timeouts, throttling, 5xx, and any unrecognized error -- is retried,
-        preserving the previous behavior for errors we do not classify.
-
-        :type e: Exception
-        :param e: The exception raised during refresh.
-
-        :rtype: bool
-        :return: True if the error is transient and should be retried.
-        """
-        # Config errors are BotoCoreErrors but can never succeed on retry.
-        if isinstance(e, (NoCredentialsError, NoRegionError)):
-            return False
-
-        # Other BotoCoreErrors are transport failures (timeouts, connection).
-        if isinstance(e, BotoCoreError):
-            return True
-
-        # Service errors: permanent only for a clear 4xx (throttling excepted).
-        if isinstance(e, ClientError):
-            code = e.response.get("Error", {}).get("Code", "")
-            if code in SecretCacheObject._THROTTLING_ERROR_CODES:
-                return True
-            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-            if status is not None and 400 <= status < 500:
-                return False
-            return True
-
-        # Unrecognized error type: retry (preserves previous behavior).
-        return True
 
     def _is_refresh_needed(self):
         """Determine if the cached object should be refreshed.
@@ -145,17 +99,12 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
             self._exception_count = 0
         except Exception as e:  # pylint: disable=broad-except
             self._exception = e
-            if self._is_transient_error(e):
-                delay = self._config.exception_retry_delay_base * (
-                    self._config.exception_retry_growth_factor ** self._exception_count
-                )
-                self._exception_count += 1
-                delay = min(delay, self._config.exception_retry_delay_max)
-                self._next_retry_time = datetime.now(timezone.utc) + timedelta(milliseconds=delay)
-            else:
-                # Clear any retry time left over from a prior transient failure
-                # so a permanent error is not automatically retried.
-                self._next_retry_time = None
+            delay = self._config.exception_retry_delay_base * (
+                self._config.exception_retry_growth_factor ** self._exception_count
+            )
+            self._exception_count += 1
+            delay = min(delay, self._config.exception_retry_delay_max)
+            self._next_retry_time = datetime.now(timezone.utc) + timedelta(seconds=delay)
 
     def get_secret_value(self, version_stage=None):
         """Get the cached secret value for the given version stage.
@@ -186,8 +135,8 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         sleep = randint(int(self.FORCE_REFRESH_JITTER_SLEEP / 2), self.FORCE_REFRESH_JITTER_SLEEP + 1)
 
         if self._exception is not None:
-            current_time_millis = int(datetime.now(timezone.utc).timestamp() * 1000)
-            exception_sleep = self._next_retry_time - current_time_millis
+            now = datetime.now(timezone.utc)
+            exception_sleep = max((self._next_retry_time - now).total_seconds() * 1000, 0)
             sleep = max(exception_sleep, sleep)
 
         # Divide by 1000 for millis

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -87,6 +87,8 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
     def __refresh(self):
         """Refresh the cached object when needed.
 
+        The caller must hold self._lock.
+
         :rtype: bool
         :return: True if the refresh attempt succeeded.
         """
@@ -133,15 +135,15 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         :rtype: bool
         :return: True if the refresh succeeded.
         """
-        self._refresh_needed = True
+        with self._lock:
+            self._refresh_needed = True
+            retry_at = self._next_retry_time if self._exception is not None else None
 
         # Generate a random number to have a sleep jitter to not get stuck in a retry loop
         sleep = randint(int(self.FORCE_REFRESH_JITTER_SLEEP / 2), self.FORCE_REFRESH_JITTER_SLEEP + 1)
 
-        retry_at = self._next_retry_time
-        if self._exception is not None and retry_at is not None:
-            now = datetime.now(timezone.utc)
-            exception_sleep = (retry_at - now).total_seconds() * 1000
+        if retry_at is not None:
+            exception_sleep = (retry_at - datetime.now(timezone.utc)).total_seconds() * 1000
             sleep = max(exception_sleep, sleep)
 
         # divide sleep(millis) by 1000 to get seconds

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -97,6 +97,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
             self._set_result(self._execute_refresh())
             self._exception = None
             self._exception_count = 0
+            self._next_retry_time = None
         except Exception as e:  # pylint: disable=broad-except
             self._exception = e
             delay = self._config.exception_retry_delay_base * (
@@ -142,7 +143,10 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         # Divide by 1000 for millis
         time.sleep(sleep / 1000)
 
-        self._execute_refresh()
+        # Refresh under the lock: __refresh stores the result and resets exception/backoff
+        # state on success, or records the exception and schedules a retry on failure.
+        with self._lock:
+            self.__refresh()
 
     def _get_result(self):
         """Get the stored result using a hook if present"""

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -88,7 +88,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         """Refresh the cached object when needed.
 
         :rtype: bool
-        :return: True if the object holds no recorded error after this call.
+        :return: True if the refresh attempt succeeded.
         """
         if not self._is_refresh_needed():
             return self._exception is None

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -131,7 +131,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         """Force a refresh of the cached secret.
 
         :rtype: bool
-        :return: True if the refresh recorded no error.
+        :return: True if the refresh succeeded.
         """
         self._refresh_needed = True
 

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -134,7 +134,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         # Generate a random number to have a sleep jitter to not get stuck in a retry loop
         sleep = randint(int(self.FORCE_REFRESH_JITTER_SLEEP / 2), self.FORCE_REFRESH_JITTER_SLEEP + 1)
 
-        if self._exception is not None:
+        if self._exception is not None and self._next_retry_time is not None:
             now = datetime.now(timezone.utc)
             exception_sleep = (self._next_retry_time - now).total_seconds() * 1000
             sleep = max(exception_sleep, sleep)

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -87,17 +87,18 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
     def __refresh(self):
         """Refresh the cached object when needed.
 
-        :rtype: None
-        :return: None
+        :rtype: bool
+        :return: True if the object holds no recorded error after this call.
         """
         if not self._is_refresh_needed():
-            return
+            return self._exception is None
         self._refresh_needed = False
         try:
             self._set_result(self._execute_refresh())
             self._exception = None
             self._exception_count = 0
             self._next_retry_time = None
+            return True
         except Exception as e:  # pylint: disable=broad-except
             self._exception = e
             delay = self._config.exception_retry_delay_base * (
@@ -106,6 +107,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
             self._exception_count += 1
             delay = min(delay, self._config.exception_retry_delay_max)
             self._next_retry_time = datetime.now(timezone.utc) + timedelta(seconds=delay)
+            return False
 
     def get_secret_value(self, version_stage=None):
         """Get the cached secret value for the given version stage.
@@ -128,37 +130,25 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
     def refresh_secret_now(self):
         """Force a refresh of the cached secret.
 
-        A failed refresh does not raise. The exception is recorded and a retry is
-        scheduled.
-
-        Note that for a cached secret this refreshes the secret metadata only; the
-        secret value for a version is fetched lazily by get_secret_value(). A True
-        result therefore does not guarantee the value itself can be retrieved.
-
         :rtype: bool
-        :return: True if this refresh recorded no error.
+        :return: True if the refresh recorded no error.
         """
         self._refresh_needed = True
 
         # Generate a random number to have a sleep jitter to not get stuck in a retry loop
         sleep = randint(int(self.FORCE_REFRESH_JITTER_SLEEP / 2), self.FORCE_REFRESH_JITTER_SLEEP + 1)
 
-        # Read _next_retry_time once. It is not protected by the lock here, so a
-        # concurrent successful refresh can clear it between the check and the use.
         retry_at = self._next_retry_time
         if self._exception is not None and retry_at is not None:
             now = datetime.now(timezone.utc)
             exception_sleep = (retry_at - now).total_seconds() * 1000
             sleep = max(exception_sleep, sleep)
 
-        # Divide by 1000 for millis
+        # divide sleep(millis) by 1000 to get seconds
         time.sleep(sleep / 1000)
 
-        # Refresh under the lock: __refresh stores the result and resets exception/backoff
-        # state on success, or records the exception and schedules a retry on failure.
         with self._lock:
-            self.__refresh()
-            return self._exception is None
+            return self.__refresh()
 
     def _get_result(self):
         """Get the stored result using a hook if present"""

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -127,17 +127,28 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
 
     def refresh_secret_now(self):
         """Force a refresh of the cached secret.
-        :rtype: None
-        :return: None
+
+        A failed refresh does not raise. The exception is recorded and a retry is
+        scheduled.
+
+        Note that for a cached secret this refreshes the secret metadata only; the
+        secret value for a version is fetched lazily by get_secret_value(). A True
+        result therefore does not guarantee the value itself can be retrieved.
+
+        :rtype: bool
+        :return: True if this refresh recorded no error.
         """
         self._refresh_needed = True
 
         # Generate a random number to have a sleep jitter to not get stuck in a retry loop
         sleep = randint(int(self.FORCE_REFRESH_JITTER_SLEEP / 2), self.FORCE_REFRESH_JITTER_SLEEP + 1)
 
-        if self._exception is not None and self._next_retry_time is not None:
+        # Read _next_retry_time once. It is not protected by the lock here, so a
+        # concurrent successful refresh can clear it between the check and the use.
+        retry_at = self._next_retry_time
+        if self._exception is not None and retry_at is not None:
             now = datetime.now(timezone.utc)
-            exception_sleep = (self._next_retry_time - now).total_seconds() * 1000
+            exception_sleep = (retry_at - now).total_seconds() * 1000
             sleep = max(exception_sleep, sleep)
 
         # Divide by 1000 for millis
@@ -147,6 +158,7 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         # state on success, or records the exception and schedules a retry on failure.
         with self._lock:
             self.__refresh()
+            return self._exception is None
 
     def _get_result(self):
         """Get the stored result using a hook if present"""

--- a/src/aws_secretsmanager_caching/cache/items.py
+++ b/src/aws_secretsmanager_caching/cache/items.py
@@ -20,6 +20,8 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from random import randint
 
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError, NoRegionError
+
 from .lru import LRUCache
 
 
@@ -50,6 +52,50 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
         self._exception_count = 0
         self._refresh_needed = True
         self._next_retry_time = None
+
+    # Throttling is the only transient error that carries a 4xx status, so it
+    # must be matched by error code rather than by the status check below.
+    _THROTTLING_ERROR_CODES = frozenset({
+        "ThrottlingException",
+        "TooManyRequestsException",
+        "Throttling",
+    })
+
+    @staticmethod
+    def _is_transient_error(e):
+        """Determine whether a refresh exception is transient (worth retrying).
+
+        Only configuration errors and clear 4xx client errors (e.g.
+        ResourceNotFound, AccessDenied) are permanent. Everything else --
+        timeouts, throttling, 5xx, and any unrecognized error -- is retried,
+        preserving the previous behavior for errors we do not classify.
+
+        :type e: Exception
+        :param e: The exception raised during refresh.
+
+        :rtype: bool
+        :return: True if the error is transient and should be retried.
+        """
+        # Config errors are BotoCoreErrors but can never succeed on retry.
+        if isinstance(e, (NoCredentialsError, NoRegionError)):
+            return False
+
+        # Other BotoCoreErrors are transport failures (timeouts, connection).
+        if isinstance(e, BotoCoreError):
+            return True
+
+        # Service errors: permanent only for a clear 4xx (throttling excepted).
+        if isinstance(e, ClientError):
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in SecretCacheObject._THROTTLING_ERROR_CODES:
+                return True
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if status is not None and 400 <= status < 500:
+                return False
+            return True
+
+        # Unrecognized error type: retry (preserves previous behavior).
+        return True
 
     def _is_refresh_needed(self):
         """Determine if the cached object should be refreshed.
@@ -99,12 +145,17 @@ class SecretCacheObject:  # pylint: disable=too-many-instance-attributes
             self._exception_count = 0
         except Exception as e:  # pylint: disable=broad-except
             self._exception = e
-            delay = self._config.exception_retry_delay_base * (
-                self._config.exception_retry_growth_factor ** self._exception_count
-            )
-            self._exception_count += 1
-            delay = min(delay, self._config.exception_retry_delay_max)
-            self._next_retry_time = datetime.now(timezone.utc) + timedelta(milliseconds=delay)
+            if self._is_transient_error(e):
+                delay = self._config.exception_retry_delay_base * (
+                    self._config.exception_retry_growth_factor ** self._exception_count
+                )
+                self._exception_count += 1
+                delay = min(delay, self._config.exception_retry_delay_max)
+                self._next_retry_time = datetime.now(timezone.utc) + timedelta(milliseconds=delay)
+            else:
+                # Clear any retry time left over from a prior transient failure
+                # so a permanent error is not automatically retried.
+                self._next_retry_time = None
 
     def get_secret_value(self, version_stage=None):
         """Get the cached secret value for the given version stage.

--- a/src/aws_secretsmanager_caching/secret_cache.py
+++ b/src/aws_secretsmanager_caching/secret_cache.py
@@ -105,5 +105,11 @@ class SecretCache:
 
         :type secret_id: str
         :param secret_id: The secret identifier
+
+        :rtype: bool
+        :return: True if the refresh recorded no error. A failed refresh does not
+            raise; the exception is recorded and a retry is scheduled. This refreshes
+            the secret metadata, so a True result does not guarantee the secret value
+            itself can be retrieved.
         """
-        self._get_cached_secret(secret_id).refresh_secret_now()
+        return self._get_cached_secret(secret_id).refresh_secret_now()

--- a/src/aws_secretsmanager_caching/secret_cache.py
+++ b/src/aws_secretsmanager_caching/secret_cache.py
@@ -107,9 +107,6 @@ class SecretCache:
         :param secret_id: The secret identifier
 
         :rtype: bool
-        :return: True if the refresh recorded no error. A failed refresh does not
-            raise; the exception is recorded and a retry is scheduled. This refreshes
-            the secret metadata, so a True result does not guarantee the secret value
-            itself can be retrieved.
+        :return: True if the secret metadata was refreshed.
         """
         return self._get_cached_secret(secret_id).refresh_secret_now()

--- a/test/unit/test_aws_secretsmanager_caching.py
+++ b/test/unit/test_aws_secretsmanager_caching.py
@@ -187,7 +187,7 @@ class TestAwsSecretsManagerCaching(unittest.TestCase):
         secret = cache._get_cached_secret('test')
         self.assertTrue(old_refresh_time == secret._next_refresh_time)
 
-        cache.refresh_secret_now('test')
+        self.assertTrue(cache.refresh_secret_now('test'))
 
         secret = cache._get_cached_secret('test')
 

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -15,20 +15,10 @@ Unit test suite for items module
 """
 import unittest
 from datetime import timezone, datetime, timedelta
-from unittest.mock import Mock
-
-from botocore.exceptions import ClientError, NoCredentialsError, ReadTimeoutError
+from unittest.mock import Mock, patch
 
 from aws_secretsmanager_caching.cache.items import SecretCacheObject, SecretCacheItem
 from aws_secretsmanager_caching.config import SecretCacheConfig
-
-
-def _client_error(code, status):
-    """Build a botocore ClientError with the given error code and HTTP status."""
-    return ClientError(
-        {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
-        "DescribeSecret",
-    )
 
 
 class TestSecretCacheObject(unittest.TestCase):
@@ -109,72 +99,39 @@ class TestSecretCacheObject(unittest.TestCase):
         t_after = datetime.now(tz=timezone.utc)
 
         t_before_delay = t_before + timedelta(
-            milliseconds=secret_cached_object._config.exception_retry_delay_base * (
+            seconds=secret_cached_object._config.exception_retry_delay_base * (
                 secret_cached_object._config.exception_retry_growth_factor ** exp_factor
             )
         )
         self.assertLessEqual(t_before_delay, secret_cached_object._next_retry_time)
 
         t_after_delay = t_after + timedelta(
-            milliseconds=secret_cached_object._config.exception_retry_delay_base * (
+            seconds=secret_cached_object._config.exception_retry_delay_base * (
                 secret_cached_object._config.exception_retry_growth_factor ** exp_factor
             )
         )
         self.assertGreaterEqual(t_after_delay, secret_cached_object._next_retry_time)
 
-    def test_is_transient_error_classification(self):
-        # Permanent service errors (4xx) -- must not be retried.
-        for code in ("ResourceNotFoundException", "AccessDeniedException",
-                     "InvalidParameterException", "DecryptionFailure",
-                     "ValidationException"):
-            self.assertFalse(
-                SecretCacheObject._is_transient_error(_client_error(code, 400)),
-                f"{code} should be permanent")
-
-        # Throttling is a 4xx but is transient -- must be retried.
-        self.assertTrue(
-            SecretCacheObject._is_transient_error(_client_error("ThrottlingException", 400)))
-
-        # 5xx server-side errors are transient.
-        for code, status in (("InternalServiceError", 500),
-                             ("InternalFailure", 500),
-                             ("ServiceUnavailable", 503)):
-            self.assertTrue(
-                SecretCacheObject._is_transient_error(_client_error(code, status)),
-                f"{code} should be transient")
-
-        # Transport-layer failures are transient; config errors are not.
-        self.assertTrue(
-            SecretCacheObject._is_transient_error(ReadTimeoutError(endpoint_url="https://x")))
-        self.assertFalse(SecretCacheObject._is_transient_error(NoCredentialsError()))
-
-        # Unknown error types default to transient, preserving the previous
-        # behavior of retrying any error we do not recognize as permanent.
-        self.assertTrue(SecretCacheObject._is_transient_error(KeyError("boom")))
-
-    def test_refresh_permanent_error_schedules_no_retry(self):
+    @patch("aws_secretsmanager_caching.cache.items.time.sleep")
+    def test_refresh_secret_now_with_pending_exception(self, mock_sleep):
+        # Regression test: when a prior refresh failed, _next_retry_time holds a
+        # datetime. The old code subtracted an int (current time in millis) from
+        # that datetime, raising TypeError. refresh_secret_now() must instead
+        # diff the two datetimes and sleep until the scheduled retry time.
         sco = SecretCacheObject(SecretCacheConfig(), None, None)
-        sco._set_result = Mock(side_effect=_client_error("ResourceNotFoundException", 400))
-        sco._refresh_needed = True
+        sco._exception = Exception("prior refresh failure")
+        sco._next_retry_time = datetime.now(timezone.utc) + timedelta(seconds=30)
+        sco._execute_refresh = Mock()
 
-        sco._SecretCacheObject__refresh()
+        # Would have raised TypeError before the fix.
+        sco.refresh_secret_now()
 
-        self.assertIsNone(sco._next_retry_time)
-        self.assertFalse(sco._is_refresh_needed())
-        self.assertIsNotNone(sco._exception)
-
-    def test_refresh_permanent_error_clears_stale_retry_time(self):
-        # A permanent error following a transient one must clear the retry
-        # time left behind, otherwise the permanent error keeps being retried.
-        sco = SecretCacheObject(SecretCacheConfig(), None, None)
-        sco._next_retry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
-        sco._set_result = Mock(side_effect=_client_error("ResourceNotFoundException", 400))
-        sco._refresh_needed = True
-
-        sco._SecretCacheObject__refresh()
-
-        self.assertIsNone(sco._next_retry_time)
-        self.assertFalse(sco._is_refresh_needed())
+        # ~30s until retry -> ~30000ms; time.sleep() receives seconds (ms / 1000).
+        mock_sleep.assert_called_once()
+        slept_seconds = mock_sleep.call_args[0][0]
+        self.assertGreater(slept_seconds, 25)
+        self.assertLess(slept_seconds, 60)
+        sco._execute_refresh.assert_called_once()
 
 
 class TestSecretCacheItem(unittest.TestCase):

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -114,8 +114,6 @@ class TestSecretCacheObject(unittest.TestCase):
 
     @patch("aws_secretsmanager_caching.cache.items.time.sleep")
     def test_force_refresh_with_retry_pending(self, mock_sleep):
-        # With a retry pending, refresh_secret_now() should not raise, should update the
-        # cache, and should clear the recorded exception/backoff state on success.
         sco = SecretCacheObject(SecretCacheConfig(), None, None)
         sco._execute_refresh = Mock(side_effect=Exception("exception used for test"))
         sco._refresh_needed = True
@@ -125,22 +123,17 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertIsNotNone(sco._next_retry_time)
 
         sco._execute_refresh = Mock(return_value="refreshed")
-        refreshed = sco.refresh_secret_now()  # would have raised TypeError before the fix
+        refreshed = sco.refresh_secret_now()
 
-        # a successful forced refresh reports True
         self.assertTrue(refreshed)
         sco._execute_refresh.assert_called_once()
-        # the fetched value is stored in the cache rather than discarded
         self.assertEqual(sco._get_result(), "refreshed")
-        # a successful forced refresh clears the recorded exception and backoff state
         self.assertIsNone(sco._exception)
         self.assertEqual(sco._exception_count, 0)
         self.assertIsNone(sco._next_retry_time)
 
     @patch("aws_secretsmanager_caching.cache.items.time.sleep")
     def test_force_refresh_reports_failure(self, mock_sleep):
-        # A failed forced refresh does not raise; it reports False and each call still
-        # attempts the refresh rather than being short-circuited by the pending backoff.
         sco = SecretCacheObject(SecretCacheConfig(), None, None)
         sco._execute_refresh = Mock(side_effect=Exception("exception used for test"))
 
@@ -150,7 +143,6 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertFalse(sco.refresh_secret_now())
         self.assertEqual(sco._execute_refresh.call_count, 2)
 
-        # the error is recorded, and with nothing cached the next read re-raises it
         self.assertIsNotNone(sco._exception)
         self.assertRaises(Exception, sco.get_secret_value)
 

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -114,20 +114,26 @@ class TestSecretCacheObject(unittest.TestCase):
 
     @patch("aws_secretsmanager_caching.cache.items.time.sleep")
     def test_force_refresh_with_retry_pending(self, mock_sleep):
-        # A failed refresh leaves _next_retry_time holding a datetime. Forcing a refresh
-        # then subtracted an int (millis) from that datetime, raising TypeError and
-        # masking the real error. Confirm the forced refresh now goes through instead.
+        # With a retry pending, refresh_secret_now() should not raise, should update the
+        # cache, and should clear the recorded exception/backoff state on success.
         sco = SecretCacheObject(SecretCacheConfig(), None, None)
         sco._execute_refresh = Mock(side_effect=Exception("exception used for test"))
         sco._refresh_needed = True
 
         sco._SecretCacheObject__refresh()
         self.assertIsNotNone(sco._exception)
+        self.assertIsNotNone(sco._next_retry_time)
 
-        sco._execute_refresh = Mock()
+        sco._execute_refresh = Mock(return_value="refreshed")
         sco.refresh_secret_now()  # would have raised TypeError before the fix
 
         sco._execute_refresh.assert_called_once()
+        # Issue #1: the fetched value is stored in the cache rather than discarded.
+        self.assertEqual(sco._get_result(), "refreshed")
+        # Issue #3: a successful forced refresh clears the recorded exception and backoff.
+        self.assertIsNone(sco._exception)
+        self.assertEqual(sco._exception_count, 0)
+        self.assertIsNone(sco._next_retry_time)
 
 
 class TestSecretCacheItem(unittest.TestCase):

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -125,8 +125,10 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertIsNotNone(sco._next_retry_time)
 
         sco._execute_refresh = Mock(return_value="refreshed")
-        sco.refresh_secret_now()  # would have raised TypeError before the fix
+        refreshed = sco.refresh_secret_now()  # would have raised TypeError before the fix
 
+        # a successful forced refresh reports True
+        self.assertTrue(refreshed)
         sco._execute_refresh.assert_called_once()
         # the fetched value is stored in the cache rather than discarded
         self.assertEqual(sco._get_result(), "refreshed")
@@ -134,6 +136,23 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertIsNone(sco._exception)
         self.assertEqual(sco._exception_count, 0)
         self.assertIsNone(sco._next_retry_time)
+
+    @patch("aws_secretsmanager_caching.cache.items.time.sleep")
+    def test_force_refresh_reports_failure(self, mock_sleep):
+        # A failed forced refresh does not raise; it reports False and each call still
+        # attempts the refresh rather than being short-circuited by the pending backoff.
+        sco = SecretCacheObject(SecretCacheConfig(), None, None)
+        sco._execute_refresh = Mock(side_effect=Exception("exception used for test"))
+
+        self.assertFalse(sco.refresh_secret_now())
+        self.assertEqual(sco._execute_refresh.call_count, 1)
+
+        self.assertFalse(sco.refresh_secret_now())
+        self.assertEqual(sco._execute_refresh.call_count, 2)
+
+        # the error is recorded, and with nothing cached the next read re-raises it
+        self.assertIsNotNone(sco._exception)
+        self.assertRaises(Exception, sco.get_secret_value)
 
 
 class TestSecretCacheItem(unittest.TestCase):

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -17,8 +17,18 @@ import unittest
 from datetime import timezone, datetime, timedelta
 from unittest.mock import Mock
 
+from botocore.exceptions import ClientError, NoCredentialsError, ReadTimeoutError
+
 from aws_secretsmanager_caching.cache.items import SecretCacheObject, SecretCacheItem
 from aws_secretsmanager_caching.config import SecretCacheConfig
+
+
+def _client_error(code, status):
+    """Build a botocore ClientError with the given error code and HTTP status."""
+    return ClientError(
+        {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        "DescribeSecret",
+    )
 
 
 class TestSecretCacheObject(unittest.TestCase):
@@ -111,6 +121,60 @@ class TestSecretCacheObject(unittest.TestCase):
             )
         )
         self.assertGreaterEqual(t_after_delay, secret_cached_object._next_retry_time)
+
+    def test_is_transient_error_classification(self):
+        # Permanent service errors (4xx) -- must not be retried.
+        for code in ("ResourceNotFoundException", "AccessDeniedException",
+                     "InvalidParameterException", "DecryptionFailure",
+                     "ValidationException"):
+            self.assertFalse(
+                SecretCacheObject._is_transient_error(_client_error(code, 400)),
+                f"{code} should be permanent")
+
+        # Throttling is a 4xx but is transient -- must be retried.
+        self.assertTrue(
+            SecretCacheObject._is_transient_error(_client_error("ThrottlingException", 400)))
+
+        # 5xx server-side errors are transient.
+        for code, status in (("InternalServiceError", 500),
+                             ("InternalFailure", 500),
+                             ("ServiceUnavailable", 503)):
+            self.assertTrue(
+                SecretCacheObject._is_transient_error(_client_error(code, status)),
+                f"{code} should be transient")
+
+        # Transport-layer failures are transient; config errors are not.
+        self.assertTrue(
+            SecretCacheObject._is_transient_error(ReadTimeoutError(endpoint_url="https://x")))
+        self.assertFalse(SecretCacheObject._is_transient_error(NoCredentialsError()))
+
+        # Unknown error types default to transient, preserving the previous
+        # behavior of retrying any error we do not recognize as permanent.
+        self.assertTrue(SecretCacheObject._is_transient_error(KeyError("boom")))
+
+    def test_refresh_permanent_error_schedules_no_retry(self):
+        sco = SecretCacheObject(SecretCacheConfig(), None, None)
+        sco._set_result = Mock(side_effect=_client_error("ResourceNotFoundException", 400))
+        sco._refresh_needed = True
+
+        sco._SecretCacheObject__refresh()
+
+        self.assertIsNone(sco._next_retry_time)
+        self.assertFalse(sco._is_refresh_needed())
+        self.assertIsNotNone(sco._exception)
+
+    def test_refresh_permanent_error_clears_stale_retry_time(self):
+        # A permanent error following a transient one must clear the retry
+        # time left behind, otherwise the permanent error keeps being retried.
+        sco = SecretCacheObject(SecretCacheConfig(), None, None)
+        sco._next_retry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+        sco._set_result = Mock(side_effect=_client_error("ResourceNotFoundException", 400))
+        sco._refresh_needed = True
+
+        sco._SecretCacheObject__refresh()
+
+        self.assertIsNone(sco._next_retry_time)
+        self.assertFalse(sco._is_refresh_needed())
 
 
 class TestSecretCacheItem(unittest.TestCase):

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -113,24 +113,20 @@ class TestSecretCacheObject(unittest.TestCase):
         self.assertGreaterEqual(t_after_delay, secret_cached_object._next_retry_time)
 
     @patch("aws_secretsmanager_caching.cache.items.time.sleep")
-    def test_refresh_secret_now_with_pending_exception(self, mock_sleep):
-        # Regression test: when a prior refresh failed, _next_retry_time holds a
-        # datetime. The old code subtracted an int (current time in millis) from
-        # that datetime, raising TypeError. refresh_secret_now() must instead
-        # diff the two datetimes and sleep until the scheduled retry time.
+    def test_force_refresh_with_retry_pending(self, mock_sleep):
+        # A failed refresh leaves _next_retry_time holding a datetime. Forcing a refresh
+        # then subtracted an int (millis) from that datetime, raising TypeError and
+        # masking the real error. Confirm the forced refresh now goes through instead.
         sco = SecretCacheObject(SecretCacheConfig(), None, None)
-        sco._exception = Exception("prior refresh failure")
-        sco._next_retry_time = datetime.now(timezone.utc) + timedelta(seconds=30)
+        sco._execute_refresh = Mock(side_effect=Exception("exception used for test"))
+        sco._refresh_needed = True
+
+        sco._SecretCacheObject__refresh()
+        self.assertIsNotNone(sco._exception)
+
         sco._execute_refresh = Mock()
+        sco.refresh_secret_now()  # would have raised TypeError before the fix
 
-        # Would have raised TypeError before the fix.
-        sco.refresh_secret_now()
-
-        # ~30s until retry -> ~30000ms; time.sleep() receives seconds (ms / 1000).
-        mock_sleep.assert_called_once()
-        slept_seconds = mock_sleep.call_args[0][0]
-        self.assertGreater(slept_seconds, 25)
-        self.assertLess(slept_seconds, 60)
         sco._execute_refresh.assert_called_once()
 
 

--- a/test/unit/test_items.py
+++ b/test/unit/test_items.py
@@ -128,9 +128,9 @@ class TestSecretCacheObject(unittest.TestCase):
         sco.refresh_secret_now()  # would have raised TypeError before the fix
 
         sco._execute_refresh.assert_called_once()
-        # Issue #1: the fetched value is stored in the cache rather than discarded.
+        # the fetched value is stored in the cache rather than discarded
         self.assertEqual(sco._get_result(), "refreshed")
-        # Issue #3: a successful forced refresh clears the recorded exception and backoff.
+        # a successful forced refresh clears the recorded exception and backoff state
         self.assertIsNone(sco._exception)
         self.assertEqual(sco._exception_count, 0)
         self.assertIsNone(sco._next_retry_time)


### PR DESCRIPTION
## Description

### Why is this change being made?

The exception-retry path in SecretCacheObject had several bugs that made the refresh backoff behave incorrectly:

- backoff was off by 1000x. __refresh used a millisecond delay instead of a second delay
- refresh_secret_now() raised a TypeError when a retry was pending. There was a mismatch from subtracting an int (millis) from _next_retry_time which is a datetime
- refresh_secret_now did not update the cache. It called _execute_refresh() and got rid of the result
- refresh_secret_now() does not have a lock



### What is changing?

1. __refresh uses timedelta(seconds=delay), bringing back the intended 1-hour cap
2. __refresh clears _next_retry_time after success, along with _exception and _exception_count
3. refresh_secret_now() guards on the _next_retry_time & _exception
4. refresh_secret_now() uses a __refresh() under the self._lock, so the fetched value is cached and the refresh no longer races on shared state.
5.  FORCE_REFRESH_MAX_SLEEP (10s) caps how much pending retry backoff a forced refresh waits out, so the restored seconds-based backoff can't make refresh_secret_now() block for up to an hour
6. **Behavior change:** a failed forced refresh previously raised but now refresh_secret_now returns a bool of True if the refresh recorded no error matching the approach in the Java caching library. SecretCache.refresh_secret_now() propagates the bool, so callers need to check the return value
   

### What has changed since the last revision
- Capped the forced-refresh wait at FORCE_REFRESH_MAX_SLEEP (10s) so the seconds-based backoff can't make refresh_secret_now() block for up to an hour.
- Moved the _refresh_needed write inside the lock in refresh_secret_now()
- Added test_force_refresh_caps_backoff_sleep and test_force_refresh_keeps_backoff_gate_closed_while_sleeping.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

- Updated the backoff test in test/unit/test_items.py to assert _next_retry_time is in seconds.
- test_force_refresh_with_retry_pending: with a retry pending, refresh_secret_now() doesn't raise TypeError, returns True, updates the cache, and resets exception/backoff state.
- test_force_refresh_reports_failure: a failed refresh returns False without raising, and each call still attempts the refresh.
- test_force_refresh_caps_backoff_sleep: with a full exception_retry_delay_max backoff pending, the forced refresh sleeps only FORCE_REFRESH_MAX_SLEEP and still refreshes.
- test_force_refresh_keeps_backoff_gate_closed_while_sleeping: the backoff gate stays closed for the duration of the sleep.
- Full unit suite (coverage + doctest gates), flake8, pylint.




### When testing locally, provide testing artifact(s):

 $ pytest test/unit
  46 passed
Required test coverage of 90% reached. Total coverage: 99.28%
  
  $ flake8
  (clean)

  $ pylint --rcfile=.pylintrc src/aws_secretsmanager_caching
  Your code has been rated at 10.00/10


---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:* Not needed
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:* Not needed
- [x] I have clearly called out breaking changes (if any)
  *If not, why:* Source-compatible, but `refresh_secret_now()` returns `bool` instead of `None` and no longer raises, so callers must check the return value. Retry backoff now honors the seconds-based config (was 3.6s, not 1 hour), so **an uncached caller can wait up to an hour before `get_secret_value()` retries.** Forced refreshes are capped at 10s.


---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
