### PR TITLE
Specify Version of Python Ruff linter for Consistency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,6 +42,8 @@ jobs:
         run: pylint --rcfile=.pylintrc src/aws_secretsmanager_caching
       - name: Check formatting with Ruff
         uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.22"
       - name: Test with pytest
         run: |
           pytest test/unit/


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Since no version was specified, the newest Ruff linter version was always referenced. By specifying a version for the Ruff linter, it ensures consistent results across different PRs.
2. A recent [update](https://github.com/astral-sh/ruff/releases#release-0.16.0) from Ruff led to 15+ linter errors from PRs on code that was not touched.


### What is changing?

1. Specify ruff to always reference 0.15.22 version to ensure consistency.


### Related Links
- **Issue #, if available**:
- N/A

---

## Testing

### How was this tested?

1. N/A

### When testing locally, provide testing artifact(s):

1. N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
